### PR TITLE
Add automated testing scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,19 @@ install-frontend:
 
 install: install-backend install-frontend
 
+
 run-backend:
 	cd backend && ./run.sh
 
 run-frontend:
 	cd frontend && ./run.sh
+
+test-backend:
+	cd backend && pytest
+
+test-frontend:
+	cd frontend && yarn test --watchAll=false
+
+test: test-backend test-frontend
 
 .DEFAULT_GOAL := install

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,29 @@
+import sys
+import types
+import os
+import pathlib
+
+# Ensure backend directory is the working directory so routers.json loads
+os.chdir(pathlib.Path(__file__).resolve().parents[1])
+
+# Stub databutton module for testing
+stub = types.SimpleNamespace(secrets=types.SimpleNamespace(get=lambda k: f"dummy_{k.lower()}"))
+sys.modules.setdefault("databutton", stub)
+
+import importlib
+import main
+importlib.reload(main)
+main.is_auth_disabled = lambda *_: True
+
+from fastapi.testclient import TestClient
+
+client = TestClient(main.create_app())
+
+
+def test_supabase_config():
+    response = client.get("/routes/supabase-config")
+    assert response.status_code == 200
+    assert response.json() == {
+        "supabaseUrl": "dummy_supabase_url",
+        "supabaseAnonKey": "dummy_supabase_anon_key",
+    }

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts'],
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@11labs/react": "0.0.4",
@@ -343,7 +344,12 @@
     "vite": "4.4.5",
     "vite-tsconfig-paths": "4.2.2",
     "@vitejs/plugin-react": "^4.0.0",
-    "@firebase/app": "^0.11.1"
+    "@firebase/app": "^0.11.1",
+    "jest": "^29.6.2",
+    "@types/jest": "^29.5.3",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.1.0"
   },
   "packageManager": "yarn@4.0.2",
   "nodeLinker": "pnpm"

--- a/frontend/tests/NotFoundPage.test.tsx
+++ b/frontend/tests/NotFoundPage.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import NotFoundPage from '../src/pages/NotFoundPage';
+
+test('renders not found message', () => {
+  render(<NotFoundPage />);
+  expect(screen.getByText('Page not found.')).toBeInTheDocument();
+});

--- a/frontend/tests/setupTests.ts
+++ b/frontend/tests/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add pytest test for `/routes/supabase-config` endpoint
- add React Testing Library and Jest setup with a NotFoundPage test
- add `make test` target to run backend and frontend tests

## Testing
- `pytest backend/tests/test_config.py -q`
- `yarn test --watchAll=false` *(fails: This package doesn't seem to be present in your lockfile)*
- `make test` *(fails: This package doesn't seem to be present in your lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_6841f70600308323976cbebf0cd6d527