### PR TITLE
Secure env config and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Backend configuration
+# Set to "production" when deploying
+DATABUTTON_SERVICE_TYPE=development
+# Additional service extensions
+DATABUTTON_EXTENSIONS=[]
+
+# Frontend configuration
+DATABUTTON_PROJECT_ID=
+DATABUTTON_CUSTOM_DOMAIN=
+# Example: [{"name":"shadcn","version":"1"}]
+DATABUTTON_EXTENSIONS=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Global ignores
+.env
+.env.*
+!.env.example
+*/.env

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ make run-frontend
 The backend server runs on port 8000 and the frontend development server runs on port 5173. The frontend Vite server proxies API requests to the backend on port 8000.
 
 Visit <http://localhost:5173> to view the application.
+
+## Security and configuration
+
+1. Copy `.env.example` to `.env` and fill in the values required for your environment.
+2. Never commit the `.env` file or any credentials to version control. The repository's `.gitignore` already excludes these files.
+3. If sensitive keys were previously committed, rotate them before deployment.
+
+The backend loads variables from `.env` at startup and the frontend uses Vite to read the same file. Keep API keys and tokens in that file locally or configure them in your deployment environment.

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,3 +1,0 @@
-DATABUTTON_PROJECT_ID=87014359-2f54-44da-a96a-53da34120d92
-DATABUTTON_CUSTOM_DOMAIN=
-DATABUTTON_EXTENSIONS=[{"name":"shadcn","version":"1"},{"name":"mcp","version":"1","config":{"public":false,"keys":[{"schema":"2025-03-25","apiKeyId":"dbtk-1-Pk7ATMdtqfcy","authCode":""},{"schema":"2025-03-25","apiKeyId":"dbtk-1-y49qgeFfnUHy","authCode":""},{"schema":"2025-03-25","apiKeyId":"dbtk-1-zDn8DljDec3o","authCode":""},{"schema":"2025-03-25","apiKeyId":"dbtk-1-wTEeBun7WJ6l","authCode":""},{"schema":"2025-03-25","apiKeyId":"dbtk-1-5Vzi59ZDSWUP","authCode":""}]}}]


### PR DESCRIPTION
## Summary
- remove committed secrets
- add .env.example and .gitignore rules
- document secure configuration process in README

## Testing
- `make` *(fails: Permission issue; manual interruption)*

------
https://chatgpt.com/codex/tasks/task_e_6841fa7825788323be13a8a5c06faeed