### PR TITLE
Add docs and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Databutton app
 
 This project consists of a FastAPI backend server and a React + TypeScript frontend application exported from Databutton.
+Additional documentation including architecture diagrams is available under [docs/](docs/).
 
 ## Stack
 
@@ -9,21 +10,23 @@ This project consists of a FastAPI backend server and a React + TypeScript front
 
 ## Quickstart
 
-1. Install dependencies:
+1. **Install dependencies** for both backend and frontend:
 
-```bash
-make
-```
+   ```bash
+   make
+   ```
 
-2. Start the backend and frontend servers in separate terminals:
+2. **Run the servers** in separate terminals:
 
-```bash
-make run-backend
-make run-frontend
-```
+   ```bash
+   make run-backend
+   make run-frontend
+   ```
 
 ## Gotchas
 
 The backend server runs on port 8000 and the frontend development server runs on port 5173. The frontend Vite server proxies API requests to the backend on port 8000.
 
 Visit <http://localhost:5173> to view the application.
+
+For more details on the architecture and usage patterns see the [documentation](docs/).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,45 @@
+# Architecture Overview
+
+This document describes the high level architecture of the project and the typical flow between the components.
+
+## System Diagram
+
+```mermaid
+graph LR
+    subgraph Client
+        A[Browser]
+    end
+    subgraph Frontend
+        B[React + Vite]
+    end
+    subgraph Backend
+        C[FastAPI]
+    end
+    A --> B
+    B -- "HTTP/JSON" --> C
+```
+
+The React application communicates with the FastAPI backend using JSON over HTTP. During development the Vite dev server proxies API requests to the backend.
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Frontend as React
+    participant Backend as FastAPI
+
+    User->>Frontend: Navigate / interact
+    Frontend->>Backend: API request with auth token
+    Backend->>Backend: Validate token and handle logic
+    Backend-->>Frontend: JSON response
+    Frontend-->>User: Update UI
+```
+
+## Key Components
+
+- **Frontend**: Located in `frontend/`, built with React and TypeScript.
+- **Backend**: Located in `backend/`, built with FastAPI. Authentication is handled using middleware based on Firebase tokens.
+- **Makefile**: Provides commands for installing dependencies and running each part.
+
+Further details on running the project and conventions can be found in the main [README](../README.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,36 @@
+# Usage Guide
+
+This guide explains common use cases and how to get the project running from scratch.
+
+## Running the project
+
+1. **Install dependencies** using the provided Makefile:
+   ```bash
+   make
+   ```
+   This installs the Python backend environment and the Node.js dependencies for the frontend.
+
+2. **Start the backend and frontend** in separate terminals:
+   ```bash
+   make run-backend
+   make run-frontend
+   ```
+   - Backend available at <http://localhost:8000>.
+   - Frontend (Vite dev server) available at <http://localhost:5173> and proxies API requests to the backend.
+
+3. Visit the frontend URL in your browser. Any API requests will be served by the FastAPI backend.
+
+## Main use cases
+
+- Provide a React interface that interacts with the FastAPI API for dynamic content.
+- Authenticate requests using Firebase tokens through the provided middleware.
+- Extend the API by adding routers under `backend/app/apis`.
+
+## Standards and good practices
+
+- **Python**: follow PEP8 style conventions. Keep dependencies managed via `uv` and list them in `requirements.txt`.
+- **TypeScript**: use ESLint and Prettier (see `frontend/README.md` for extending the lint rules). Keep components typed and avoid `any`.
+- **Version control**: use concise commits and keep `.gitignore` patterns in each subproject to avoid committing virtual environments or build artifacts.
+- **Environment variables**: store secrets in a `.env` file and do not commit it to version control.
+
+For further reference on the project structure see the [Architecture Overview](architecture.md).


### PR DESCRIPTION
## Summary
- add documentation folder with architecture and usage guides
- link new docs from README

## Testing
- `make` *(fails: ./install.sh: line 4: ./venv/bin/activate: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684201f358408323a5967ead5ea20644